### PR TITLE
[optim] dashboard : make only 1 api call instead of 2

### DIFF
--- a/src/components/organisms/dasboardDisclosure/dasboardDisclosure.jsx
+++ b/src/components/organisms/dasboardDisclosure/dasboardDisclosure.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import axios from 'axios'
 import DisclosureTypesIssues from './disclosureTypesIssues'
 
@@ -18,31 +18,16 @@ const initialOpeningState = SENSOR_TYPES.reduce((accu, sensor) => ({
   [sensor] : sensor === 'high_humidity' ? true : false
 }), {}) 
 
-const DasboardDisclosure = () => {
-  const [dataTypeIssues, setDataTypeIssues] = useState([]);
+const DasboardDisclosure = ({ incidentsOfAllTime }) => {
   const [disclosureIds, setDisclosureIds] = useState(initialOpeningState)
 
   const disclosureCallback = (value) => {
     setDisclosureIds(value)
   }
 
-  useEffect(() => {
-    getIncindentsType()
-  }, [])
-
-  const getIncindentsType = async () => {
-    try {
-      const response = await axios.get(`${import.meta.env.VITE_API_URL}api/dashboard/statsincidents/1`)
-      if (!response || !response.data) return
-      setDataTypeIssues(response.data.incidents)
-    } catch (error) {
-      console.log(error)
-    }
-  };
-
   return (
     <div>
-      {dataTypeIssues &&
+      {incidentsOfAllTime &&
         Object.entries(disclosureIds).map(
           ([key, value]) => (
             <DisclosureTypesIssues
@@ -51,12 +36,12 @@ const DasboardDisclosure = () => {
               isOpen={value}
               setter={disclosureCallback}
               initialState={neutralOpeningState}
-              incidents={dataTypeIssues}
+              incidents={incidentsOfAllTime}
             />
           )
         )}
     </div>
-  );
-};
+  )
+}
 
 export default DasboardDisclosure

--- a/src/components/organisms/incidentsOfTheMonth/incidentsOfTheMonth.jsx
+++ b/src/components/organisms/incidentsOfTheMonth/incidentsOfTheMonth.jsx
@@ -5,61 +5,32 @@ import MonthlySensorChart from '../../molecules/currentMonthChart/currentMonthCh
 import VariationStat from '../../atoms/variationStat/variationStat'
 import MainStat from '../../atoms/mainStat/mainStat'
 
-function IncidentsOfTheMonth() {
-  // api incident data = incidents of all time.
-  // just keep incidents of the current month regardless of incidents status.
-  // The date corresponds to de incident creation date.
-
-  const [chartData, setChartData] = useState(undefined);
-  const [numberIncidentThisMonth, setNumberIncidentThisMonth] = useState(undefined);
+function IncidentsOfTheMonth({ incidentsOfTheMonth, numberIncidentsPrevMonth, numberIncidentsThisMonth }) {
   const [variationWithPrevMonth, setVariationWithPrevMonth] = useState(undefined);
   const [variationText, setVariationText] = useState(undefined);
 
-  useEffect(async () => {
-    await getChartData();
-  }, []);
+  useEffect(() => {
+    calculateVariation();
+  }, [numberIncidentsPrevMonth, numberIncidentsThisMonth]);
 
-  async function getChartData() {
-    try {
-      const response = await axios.get(`${import.meta.env.VITE_API_URL}api/dashboard/statsincidents/1`)
-      if (!response || !response.data) return
-      
-      const statsIncidents = response.data
-      const currentMonthIncidents = {}
-      const currentMonth = new Date().getMonth()
+  async function calculateVariation() {
+    const variation = (numberIncidentsThisMonth - numberIncidentsPrevMonth) / numberIncidentsPrevMonth
+    const formattedVariation = formatPercentage(variation)
 
-      Object.entries(statsIncidents.incidents).forEach(([key, value]) => {
-        currentMonthIncidents[key] = value.filter(
-          (incident) =>
-            new Date(incident.incident_date).getMonth() === currentMonth
-        );
-      });
+    if (variation >= 0) setVariationWithPrevMonth('+' + formattedVariation)
+    else setVariationWithPrevMonth(formattedVariation)
 
-      const countIncidentsPreviousMonth = statsIncidents.info.total_incidents_prev_month
-      const countIncidentsCurrentMonth = statsIncidents.info.total_incidents_current_month
-      const variation = (countIncidentsCurrentMonth - countIncidentsPreviousMonth) / countIncidentsPreviousMonth
-      const formattedVariation = formatPercentage(variation)
-
-      if (variation >= 0) setVariationWithPrevMonth('+' + formattedVariation)
-      else setVariationWithPrevMonth(formattedVariation)
-
-      if (variation === 0) setVariationText('Stable depuis le mois précédent')
-      else if (variation > 0) setVariationText('En hausse depuis le mois précédent')
-      else setVariationText('En baisse depuis le mois précédent')
-
-      setChartData(currentMonthIncidents)
-      setNumberIncidentThisMonth(countIncidentsCurrentMonth)
-    } catch (error) {
-      console.log(error)
-    }
+    if (variation === 0) setVariationText('Stable depuis le mois précédent')
+    else if (variation > 0) setVariationText('En hausse depuis le mois précédent')
+    else setVariationText('En baisse depuis le mois précédent')
   }
   return (
     <div className="month-incidents-chart">
       <div className="month-incidents-chart__header">
-        <MainStat amount={numberIncidentThisMonth}/>
+        <MainStat amount={numberIncidentsThisMonth}/>
         <VariationStat variation={variationWithPrevMonth} variationText={variationText}/>
       </div>
-      <MonthlySensorChart chartData={chartData} numberIncident={numberIncidentThisMonth}/>
+      <MonthlySensorChart chartData={incidentsOfTheMonth} numberIncident={numberIncidentsThisMonth}/>
     </div>
   );
 }

--- a/src/components/pages/home/Home.jsx
+++ b/src/components/pages/home/Home.jsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import axios from 'axios'
 import IncidentsOfTheMonth from '../../organisms/incidentsOfTheMonth/incidentsOfTheMonth'
 import CommingInterventions from '../../organisms/commingInterventions/CommingInterventions'
 import EstablishmentInfo from '../../organisms/establishmentInfo/establishmentInfo'
@@ -8,11 +9,67 @@ import Card from '../../templates/card/Card'
 import Page from '../../templates/page/Page'
 
 const Home = () => {
+  // api incident data = incidents of all time.
+  // just keep incidents of the current month regardless of incidents status.
+  // The date corresponds to de incident creation date.
+
+  const [incidentsOfAllTime, setIncidentsOfAllTime] = useState(null)
+  const [incidentsInfo, setIncidentsInfo] = useState(null)
+  const [incidentsOfTheMonth, setIncidentsOfTheMonth] = useState(null)
+  const [incidentsPrevMonth, setIncidentsPrevMonth] = useState(0)
+  const [incidentsThisMonth, setIncidentsThisMonth] = useState(0)
+
+  useEffect(() => {
+    getIncidentsOfAllTime()
+  }, [])
+
+  useEffect(() => {
+    getIncidentsOfTheMonth()
+  }, [incidentsOfAllTime])
+
+  useEffect(() => {
+    getNumberIncidentsPrevAndCurrentMonth()
+  }, [incidentsInfo])
+
+  async function getIncidentsOfAllTime () {
+    try {
+      const response = await axios.get(`${import.meta.env.VITE_API_URL}api/dashboard/statsincidents/1`)
+      if (!response || !response.data) return
+      setIncidentsOfAllTime(response.data.incidents)
+      setIncidentsInfo(response.data.info)
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  function getIncidentsOfTheMonth () {
+    if (!incidentsOfAllTime) return
+    const currentMonthIncidents = {}
+    const currentMonth = new Date().getMonth()
+
+    Object.entries(incidentsOfAllTime).forEach(([key, value]) => {
+      currentMonthIncidents[key] = value.filter(
+        (incident) => new Date(incident.incident_date).getMonth() === currentMonth
+      )
+    })
+    setIncidentsOfTheMonth(currentMonthIncidents)
+  }
+
+  function getNumberIncidentsPrevAndCurrentMonth () {
+    if (!incidentsInfo) return
+    setIncidentsPrevMonth(incidentsInfo.total_incidents_prev_month)
+    setIncidentsThisMonth(incidentsInfo.total_incidents_current_month)
+  }
+
   return (
     <Page className="home">
       <Card>
-        <IncidentsOfTheMonth />
-        <DasboardDisclosure />
+        <IncidentsOfTheMonth incidentsOfTheMonth={incidentsOfTheMonth} numberIncidentsPrevMonth={incidentsPrevMonth} numberIncidentsThisMonth={incidentsThisMonth} />
+       
+        {/* TODO: confirm that we should display the current month data only in the disclosure
+        if yes, change the displayed data to only show current month data
+        if no, everything is fine */}
+        <DasboardDisclosure incidentsOfAllTime={incidentsOfAllTime} />
       </Card>
       <div className="card-container">
         <CommingInterventions />

--- a/src/components/pages/home/Home.scss
+++ b/src/components/pages/home/Home.scss
@@ -8,6 +8,7 @@
   }
   .card-container {
     margin-left: $large-space;
+    min-width: 50%;
 
     & > div {
       margin: $large-space 0;


### PR DESCRIPTION
Regroupement des 2 calls api vers api/dashboard/statsincidents/1 en 1 seul.

TODO: voir avec tout le monde si les data affichées dans le disclosure du dashboard sont celles de toute l'année ou uniquement du mois en cours (selon moi si on regarde le design c'est que ce mois-ci).

En fonction il faudra changer les data affichées